### PR TITLE
Fix substring matching in the port conflict check

### DIFF
--- a/service_config/config.py
+++ b/service_config/config.py
@@ -30,7 +30,9 @@ def check_ports(ports: str, cursor: Cursor):
             raise InvalidPortMappingException()
 
         external = port.split(':')[0]
-        cursor.execute("select port from repos WHERE port REGEXP ?", (f'.*{external}:.*',))
+        # the external port has to start a mapping (beginning of the string or
+        # right after a comma), otherwise e.g. 80 would collide with 8080:80
+        cursor.execute("select port from repos WHERE port REGEXP ?", (f'(.*,)?{external}:.*',))
         existing_mappings = cursor.fetchall()
 
         if len(existing_mappings):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -98,3 +98,29 @@ def test_check_ports_accepts_distinct_external_port(cursor):
         " '9090:90', '.', '', '')"
     )
     assert check_ports("8080:80", cursor) is True
+
+
+def test_check_ports_accepts_suffix_of_used_external_port(cursor):
+    # regression for issue #141: 80 is free even though 8080 is taken
+    cursor.execute(
+        "INSERT INTO repos VALUES ('svc', 'url', 'docker', 'RUNNING',"
+        " '8080:80', '.', '', '')"
+    )
+    assert check_ports("80:80", cursor) is True
+
+
+def test_check_ports_accepts_external_port_containing_used_one(cursor):
+    cursor.execute(
+        "INSERT INTO repos VALUES ('svc', 'url', 'docker', 'RUNNING',"
+        " '80:80', '.', '', '')"
+    )
+    assert check_ports("8080:8080", cursor) is True
+
+
+def test_check_ports_detects_conflict_after_comma(cursor):
+    cursor.execute(
+        "INSERT INTO repos VALUES ('svc', 'url', 'docker', 'RUNNING',"
+        " '9090:90,8080:80', '.', '', '')"
+    )
+    with pytest.raises(PortAlreadyUsedException):
+        check_ports("8080:80", cursor)


### PR DESCRIPTION
`check_ports` rejected free ports whose number is a suffix of a used external port (registering `80:80` failed while `8080:80` existed), because the REGEXP pattern `.*{external}:.*` matches anywhere in the stored mapping string.

The pattern is now `(.*,)?{external}:.*`, anchoring the external port at the beginning of the stored string or directly after a comma. Regression tests cover both suffix directions and the conflict-after-comma case.

Fixes #141