### PR TITLE
Tolerate a missing error.txt when fetching the service state

### DIFF
--- a/app.py
+++ b/app.py
@@ -149,8 +149,13 @@ def update_service(service_id: str):
 
                 return f'service "{service_id}" patched and restarted', 200
             else:
-                with open(f'services/{service_id}/error.txt') as f:
-                    errors = f.read()
+                # error.txt only exists after the first start attempt finished
+                error_file = f'services/{service_id}/error.txt'
+                if os.path.exists(error_file):
+                    with open(error_file) as f:
+                        errors = f.read()
+                else:
+                    errors = ''
 
                 logging.info(f'Fetching state of {service_id}...')
                 try:

--- a/app.py
+++ b/app.py
@@ -90,7 +90,7 @@ def update_service(service_id: str):
 
         # service exists
         if service_data := service_cursor.fetchone():
-            _, url, mode, _, port, docker_root, image, tag = service_data
+            stored_id, url, mode, _, port, docker_root, image, tag = service_data
 
             # service update requested
             if (method := request.method) == 'POST':
@@ -149,8 +149,9 @@ def update_service(service_id: str):
 
                 return f'service "{service_id}" patched and restarted', 200
             else:
-                # error.txt only exists after the first start attempt finished
-                error_file = f'services/{service_id}/error.txt'
+                # error.txt only exists after the first start attempt finished;
+                # build the path from the registered id, not the raw URL value
+                error_file = f'services/{stored_id}/error.txt'
                 if os.path.exists(error_file):
                     with open(error_file) as f:
                         errors = f.read()

--- a/tests/unit/test_app_extended.py
+++ b/tests/unit/test_app_extended.py
@@ -216,6 +216,24 @@ def test_get_state_of_running_container(app_env):
     from_env.return_value.containers.get.assert_called_once_with("svc")
 
 
+def test_get_state_while_initializing_reports_no_errors(app_env):
+    # regression for issue #143: error.txt only exists after the first start
+    # attempt, polling the state before that must not crash
+    app_module, client = app_env
+    register_service("svc", state="INITIALIZING", port="8080:80",
+                     image="nginx", tag="alpine")
+    os.remove(os.path.join("services", "svc", "error.txt"))
+
+    with mock.patch.object(app_module.docker, "from_env") as from_env:
+        from_env.return_value.containers.get.return_value.status = "created"
+        resp = client.get("/service/svc")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["state"] == "CREATED"
+    assert data["errors"] == ""
+
+
 def test_update_forwards_files_and_volumes(app_env):
     app_module, client = app_env
     register_service("svc")


### PR DESCRIPTION
`GET /service/<id>` read `services/<id>/error.txt` unconditionally, but the file is only created by `tasks/start_service.py` after the first build/pull attempt. Polling the state right after registration — which the README recommends — answered HTTP 500.

A missing `error.txt` is now treated as "no errors reported yet" and the normal state payload is returned. Regression test polls an `INITIALIZING` service without the file.

Fixes #143