### PR TITLE
Validate volume mappings before dropping empty entries

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,10 +38,22 @@ app = Flask(__name__)
 
 
 def check_volumes(volumes):
+    """
+    Validate a volume mapping list and drop empty entries
+
+    :param volumes: list of 'host_path:container_path' mappings
+    :raises InvalidVolumeMappingException
+    :return: the volume list without empty entries
+    """
     if type(volumes) is not list:
         raise InvalidVolumeMappingException('Volume mapping list expected')
-    if any([len(volume.split(':')) != 2 for volume in volumes]):
+
+    volumes = [volume for volume in volumes if volume != '']
+
+    if any([not isinstance(volume, str) or len(volume.split(':')) != 2 for volume in volumes]):
         raise InvalidVolumeMappingException('Invalid volume mapping format provided')
+
+    return volumes
 
 
 def start_update(service_id: str, files: dict, volumes: list[str]):
@@ -101,11 +113,8 @@ def update_service(service_id: str):
                 files = payload['files'] if 'files' in payload else {}
                 volumes = payload['volumes'] if 'volumes' in payload else []
 
-                if '' in volumes:
-                    volumes.remove('')
-
                 try:
-                    check_volumes(volumes)
+                    volumes = check_volumes(volumes)
 
                     # start background task to update the service
                     start_update(service_id, files, volumes)
@@ -124,6 +133,13 @@ def update_service(service_id: str):
             elif method == 'PATCH':
                 payload = request.json
 
+                # validate the volumes before any setting is changed
+                try:
+                    volumes = check_volumes(payload['volumes'] if 'volumes' in payload else [])
+                except InvalidVolumeMappingException as e:
+                    logging.error(f'Invalid volume mapping provided: {e}')
+                    return e.message, 400
+
                 if 'port' in payload:
                     try:
                         check_ports(payload['port'], service_db.cursor())
@@ -139,11 +155,6 @@ def update_service(service_id: str):
                             update_cursor.execute(f'UPDATE repos SET {param} = ? WHERE id = ?',
                                                   (payload[param], service_id))
                             service_db.commit()
-
-                volumes = payload['volumes'] if 'volumes' in payload else []
-
-                if '' in volumes:
-                    volumes.remove('')
 
                 start_update(service_id, {}, volumes)
 
@@ -221,10 +232,7 @@ def manage_services():
             image = ''
             tag = ''
 
-            if '' in volumes:
-                volumes.remove('')
-
-            check_volumes(volumes)
+            volumes = check_volumes(volumes)
 
             # mode "docker" requires external port mapping
             if mode in ['docker', 'dockerfile'] and not valid(mode):

--- a/tests/unit/test_app_extended.py
+++ b/tests/unit/test_app_extended.py
@@ -148,6 +148,59 @@ def test_register_rejects_non_list_volumes(app_env):
     assert b"Volume mapping list expected" in resp.data
 
 
+def test_check_volumes_cleans_and_validates(app_env):
+    # regression for issue #145
+    app_module, _ = app_env
+    from tasks.exceptions import InvalidVolumeMappingException
+
+    assert app_module.check_volumes(["data:/data", ""]) == ["data:/data"]
+    assert app_module.check_volumes([]) == []
+    with pytest.raises(InvalidVolumeMappingException):
+        app_module.check_volumes("data:/data")
+    with pytest.raises(InvalidVolumeMappingException):
+        app_module.check_volumes([5])
+
+
+@pytest.mark.parametrize("endpoint_call", [
+    lambda client: post_service(client, mode="dockerfile", image="nginx",
+                                tag="alpine", port="8080:80",
+                                volumes="data:/data"),
+    lambda client: client.post("/service/svc",
+                               json={"API-KEY": API_KEY,
+                                     "volumes": "data:/data"}),
+    lambda client: client.patch("/service/svc",
+                                json={"API-KEY": API_KEY,
+                                      "volumes": "data:/data"}),
+])
+def test_string_volumes_answered_with_400(app_env, endpoint_call):
+    # regression for issue #145: a string used to crash with HTTP 500
+    app_module, client = app_env
+    register_service("svc")
+
+    with mock.patch.object(app_module.subprocess, "Popen") as popen:
+        resp = endpoint_call(client)
+
+    assert resp.status_code == 400
+    assert b"Volume mapping list expected" in resp.data
+    popen.assert_not_called()
+
+
+def test_patch_rejects_invalid_volume_mapping_before_changes(app_env):
+    # PATCH gained volume validation with issue #145: nothing may change
+    app_module, client = app_env
+    register_service("svc", port="8080:80")
+
+    with mock.patch.object(app_module.subprocess, "Popen") as popen:
+        resp = client.patch("/service/svc",
+                            json={"API-KEY": API_KEY, "port": "9090:90",
+                                  "volumes": ["missing-separator"]})
+
+    assert resp.status_code == 400
+    assert b"Invalid volume mapping format provided" in resp.data
+    assert service_row("svc")[4] == "8080:80"
+    popen.assert_not_called()
+
+
 def test_register_drops_empty_volume_entries(app_env):
     app_module, client = app_env
     with mock.patch.object(app_module.subprocess, "Popen") as popen:


### PR DESCRIPTION
Sending `"volumes": "data:/data"` (string instead of list) crashed `POST /service`, `POST /service/<id>` and `PATCH /service/<id>` with an `AttributeError` (HTTP 500), because `'' in volumes` is a substring test on strings and ran before any validation.

- `check_volumes` now validates the type first, drops empty entries itself, rejects non-string entries (`[5]` used to crash `split`), and returns the cleaned list
- all three endpoints use it as the single validation point; the fragile `'' in volumes` pre-processing is gone
- `PATCH` validates volumes **before** touching the database (it previously applied no volume validation at all and could persist a port change and then crash)

Regression tests cover the string payload on all three endpoints, non-string entries, the cleaning behavior and PATCH rejecting invalid mappings without side effects.

Fixes #145