### PR TITLE
Harden API against reflected XSS and path traversal

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,10 @@
 from flask import Flask, request, jsonify, redirect, url_for
+from markupsafe import escape
 import os
 import sqlite3
 from service_config.config import modes, check_ports, regexp, InvalidPortMappingException, PortAlreadyUsedException
 from tasks.init_repo import load_repository
-from tasks.exceptions import InvalidVolumeMappingException, RepositoryAlreadyExistsException
+from tasks.exceptions import InvalidVolumeMappingException, RepositoryAlreadyExistsException, InvalidPathException
 import subprocess
 import json
 from git import GitCommandError
@@ -54,6 +55,29 @@ def check_volumes(volumes):
         raise InvalidVolumeMappingException('Invalid volume mapping format provided')
 
     return volumes
+
+
+def check_files(files):
+    """
+    Validate a custom file mapping
+
+    :param files: dict of (relative file path, file content) pairs
+    :raises InvalidPathException
+    :return: the validated file mapping
+    """
+    if type(files) is not dict:
+        raise InvalidPathException('File mapping object expected')
+
+    for file, content in files.items():
+        if not isinstance(file, str) or not isinstance(content, str):
+            raise InvalidPathException('File names and contents have to be strings')
+
+        # the path has to stay inside the service's directory
+        normalized = os.path.normpath(file)
+        if normalized == '.' or os.path.isabs(normalized) or normalized.startswith('..'):
+            raise InvalidPathException('Invalid file path provided')
+
+    return files
 
 
 def start_update(service_id: str, files: dict, volumes: list[str]):
@@ -115,18 +139,20 @@ def update_service(service_id: str):
 
                 try:
                     volumes = check_volumes(volumes)
+                    files = check_files(files)
 
                     # start background task to update the service
                     start_update(service_id, files, volumes)
                     return 'Update initiated', 200
-                except InvalidVolumeMappingException as e:
-                    logging.error(f'Invalid volume mapping provided: {e}')
+                except (InvalidVolumeMappingException, InvalidPathException) as e:
+                    logging.error(f'Invalid update payload provided: {e.message}')
                     return e.message, 400
             elif method == 'DELETE':
                 delete_process = subprocess.run(['python', 'tasks/delete_repo.py', service_id])
 
                 if delete_process.returncode == 0:
-                    return f'{service_id} removed', 200
+                    # echo the registered id, not the raw URL value
+                    return f'{stored_id} removed', 200
                 else:
                     logging.error(f'deletion of {service_id} failed')
                     return 'deletion not completed', 500
@@ -158,7 +184,7 @@ def update_service(service_id: str):
 
                 start_update(service_id, {}, volumes)
 
-                return f'service "{service_id}" patched and restarted', 200
+                return f'service "{stored_id}" patched and restarted', 200
             else:
                 # error.txt only exists after the first start attempt finished;
                 # build the path from the registered id, not the raw URL value
@@ -189,7 +215,7 @@ def update_service(service_id: str):
         # service does not exist
         else:
             logging.warning(f'Service {service_id} not found.')
-            return f'{service_id} not found', 404
+            return f'{escape(service_id)} not found', 404
 
 
 @app.route('/service/', methods=['GET', 'POST'])
@@ -233,6 +259,7 @@ def manage_services():
             tag = ''
 
             volumes = check_volumes(volumes)
+            files = check_files(files)
 
             # mode "docker" requires external port mapping
             if mode in ['docker', 'dockerfile'] and not valid(mode):
@@ -280,8 +307,8 @@ def manage_services():
         except KeyError as e:
             logging.error(f'Needed parameters not provided! {e}')
             return 'Missing argument', 400
-        except InvalidVolumeMappingException as e:
-            logging.error(f'Invalid volume mapping provided: {e}')
+        except (InvalidVolumeMappingException, InvalidPathException) as e:
+            logging.error(f'Invalid registration payload provided: {e.message}')
             return e.message, 400
 
         return jsonify({'id': service_id, 'state': 'CREATED'}), 200

--- a/tasks/exceptions.py
+++ b/tasks/exceptions.py
@@ -10,3 +10,12 @@ class InvalidVolumeMappingException(Exception):
     """
     def __init__(self, message):
         self.message = message
+
+
+class InvalidPathException(Exception):
+    """
+    Raised, if a provided service id or file path would escape its
+    designated directory
+    """
+    def __init__(self, message):
+        self.message = message

--- a/tasks/init_repo.py
+++ b/tasks/init_repo.py
@@ -2,7 +2,7 @@ import logging
 
 from git import Repo
 import sqlite3
-from tasks.exceptions import RepositoryAlreadyExistsException
+from tasks.exceptions import RepositoryAlreadyExistsException, InvalidPathException
 import os
 
 
@@ -18,6 +18,7 @@ def load_repository(url: str, mode: str, port: str, docker_root: str, dockerfile
     :param dockerfile: docker image name from dockerhub
     :param tag: tag of dockerfile
     :raises RepositoryAlreadyExistsException
+    :raises InvalidPathException
     :return: id of the created repository
     """
     if files is None:
@@ -27,7 +28,10 @@ def load_repository(url: str, mode: str, port: str, docker_root: str, dockerfile
     else:
         link = '-'.join(url.lower().replace('//', '').split('/')[1:]).replace('.git', '')
 
-    repo_path = os.path.join('services', link)
+    # the derived id has to stay below the services directory
+    repo_path = os.path.normpath(os.path.join('services', link))
+    if not repo_path.startswith('services' + os.sep):
+        raise InvalidPathException('Invalid service id')
 
     # repository already exists
     if os.path.exists(repo_path):
@@ -47,7 +51,10 @@ def load_repository(url: str, mode: str, port: str, docker_root: str, dockerfile
 
     # add all optional files to repository
     for file in files:
-        file_path = os.path.join(repo_path, file.replace("..", "."))
+        # custom files have to stay inside the service's directory
+        file_path = os.path.normpath(os.path.join(repo_path, file))
+        if not file_path.startswith(repo_path + os.sep):
+            raise InvalidPathException('Invalid file path provided')
 
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
 

--- a/tasks/update_service.py
+++ b/tasks/update_service.py
@@ -66,11 +66,16 @@ if __name__ == '__main__':
                 repo.remote('origin').pull()
 
             # update custom files
+            service_dir = os.path.normpath(os.path.join('services', service_id))
             for file in files:
-                file_path = f'services/{service_id}/{file.replace("..", ".")}'
+                # custom files have to stay inside the service's directory
+                file_path = os.path.normpath(os.path.join(service_dir, file))
+                if not file_path.startswith(service_dir + os.sep):
+                    logging.warning(f'Skipping invalid file path {file}')
+                    continue
 
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
-                    
+
                 with open(file_path, 'w') as f:
                     f.write(files[file])
 

--- a/tests/unit/test_app_extended.py
+++ b/tests/unit/test_app_extended.py
@@ -269,6 +269,62 @@ def test_get_state_of_running_container(app_env):
     from_env.return_value.containers.get.assert_called_once_with("svc")
 
 
+@pytest.mark.parametrize("files", [
+    ["not-a-dict"],                    # wrong type
+    {"../escape.txt": "pwned"},        # traversal
+    {"/etc/evil.txt": "pwned"},        # absolute path
+    {"a/../../escape.txt": "pwned"},   # nested traversal
+    {"": "empty name"},                # empty path
+    {"config.txt": 5},                 # non-string content
+])
+def test_register_rejects_invalid_files(app_env, files):
+    # hardening from issue #150
+    app_module, client = app_env
+    with mock.patch.object(app_module.subprocess, "Popen") as popen:
+        resp = post_service(client, mode="dockerfile", image="nginx",
+                            tag="alpine", port="8080:80", files=files)
+
+    assert resp.status_code == 400
+    assert not os.path.exists(os.path.join("services", "nginx"))
+    popen.assert_not_called()
+
+
+def test_update_rejects_escaping_file_path(app_env):
+    # hardening from issue #150
+    app_module, client = app_env
+    register_service("svc")
+
+    with mock.patch.object(app_module.subprocess, "Popen") as popen:
+        resp = client.post("/service/svc",
+                           json={"API-KEY": API_KEY,
+                                 "files": {"../escape.txt": "pwned"}})
+
+    assert resp.status_code == 400
+    assert b"Invalid file path provided" in resp.data
+    popen.assert_not_called()
+
+
+def test_register_rejects_escaping_service_id(app_env):
+    # hardening from issue #150: an image name of '..' must not resolve
+    # to a directory outside services/
+    _, client = app_env
+    resp = post_service(client, mode="dockerfile", image="..", tag="1.0",
+                        port="8080:80")
+
+    assert resp.status_code == 400
+    assert b"Invalid service id" in resp.data
+
+
+def test_unknown_service_id_is_escaped_in_404(app_env):
+    # hardening from issue #150: the 404 echoes the id HTML-escaped
+    _, client = app_env
+    resp = client.get("/service/<img%20src=x%20onerror=alert(1)>")
+
+    assert resp.status_code == 404
+    assert b"<img" not in resp.data
+    assert b"&lt;img" in resp.data
+
+
 def test_get_state_while_initializing_reports_no_errors(app_env):
     # regression for issue #143: error.txt only exists after the first start
     # attempt, polling the state before that must not crash

--- a/tests/unit/test_init_repo.py
+++ b/tests/unit/test_init_repo.py
@@ -11,7 +11,7 @@ from unittest import mock
 import pytest
 
 from tasks import init_repo
-from tasks.exceptions import RepositoryAlreadyExistsException
+from tasks.exceptions import InvalidPathException, RepositoryAlreadyExistsException
 from tasks.init_repo import load_repository
 
 
@@ -54,14 +54,23 @@ def test_load_repository_rejects_existing_repository(workspace):
         )
 
 
-def test_load_repository_custom_file_cannot_escape_service_dir(workspace):
-    load_repository(
-        url="", mode="dockerfile", port="8080:80", docker_root=".",
-        dockerfile="myimage", tag="1.0", files={"../escape.txt": "pwned"},
-    )
-    # the ".." is neutralized, so the file lands inside the service directory
+def test_load_repository_rejects_escaping_custom_file(workspace):
+    # hardening from issue #150: traversal is rejected, no longer rewritten
+    with pytest.raises(InvalidPathException):
+        load_repository(
+            url="", mode="dockerfile", port="8080:80", docker_root=".",
+            dockerfile="myimage", tag="1.0", files={"../escape.txt": "pwned"},
+        )
+
     assert not os.path.exists(os.path.join("services", "escape.txt"))
-    assert os.path.exists(os.path.join("services", "myimage", "escape.txt"))
+
+
+def test_load_repository_rejects_escaping_service_id(workspace):
+    with pytest.raises(InvalidPathException):
+        load_repository(
+            url="", mode="dockerfile", port="8080:80", docker_root=".",
+            dockerfile="..", tag="1.0",
+        )
 
 
 def test_load_repository_git_mode_derives_id_from_url(workspace):


### PR DESCRIPTION
Resolves the 7 open CodeQL alerts (3× `py/reflective-xss` in app.py, 4× `py/path-injection` in tasks/init_repo.py), see #150:

- **XSS**: `DELETE`/`PATCH` success messages now echo the id from the database row (taint-free, byte-identical response for legitimate ids); the 404 message escapes the raw URL value with `markupsafe.escape`.
- **Path traversal**: `load_repository` normalizes and validates the derived service directory and every custom file path against its base directory (`InvalidPathException` → HTTP 400), replacing the `file.replace("..", ".")` rewrite. New `check_files` validation runs in both `POST /service` and `POST /service/<id>` before anything is written or spawned; the background update task additionally skips escaping paths with a warning.

**API change**: invalid `files` payloads (non-object, non-string keys/values, absolute or `..`-escaping paths) are now rejected with HTTP 400 — previously traversal paths were silently rewritten into the service directory and type errors crashed with HTTP 500.

12 new/updated tests cover traversal, absolute paths, type validation, the escaped 404 and the service-id guard.

Fixes #150