### PR TITLE
Low-downtime updates: prepare image first, readiness probe, rollback (#149 phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The API provides the following endpoints:
       "port": "port mapping (eg. '80:80' or '80:80,443:443') (optional)",
       "image": "dockerhub image (optional)",
       "tag": "dockerhub image tag (optional)",
+      "health_path": "HTTP readiness probe path, eg. '/health' (optional)",
       "files": {
         "path_and_file_name": "file content"
       },
@@ -124,16 +125,33 @@ The API provides the following endpoints:
       }
     }
     ```
-    **Remark**: The docker service will be rebuilt and restarted from scratch. All data will be lost!
+    **Remark**: The updated image is built (or pulled) **while the old container keeps
+    serving**; only then are the containers swapped, so the downtime is reduced to the
+    swap itself. If the build fails or the new container does not become ready (see
+    `health_path` below), the previous image is restored and the service state becomes
+    `UPDATE FAILED` — the reason is available via the `GET` request. The container is
+    still recreated from scratch, so all data inside the container is lost; use
+    `volumes` for persistent data.
+
+    ### Readiness probe (`health_path`)
+    If a `health_path` (e.g. `/health`) is configured for a service, an update is only
+    considered successful once the new container answers `HTTP 200` on that path
+    (probed via the container's bridge IP and the mapped port, timeout 60 s). Without
+    a configured `health_path`, the running container state counts as ready. The probe
+    requires the updater to reach the managed containers — the provided
+    `docker-compose.yml` attaches the updater to the default bridge network for that
+    purpose (`network_mode: bridge`).
     
-  * `PATCH`-Request: Updates the settings of your service. You can change `port` and `tag` of the Docker image.
+  * `PATCH`-Request: Updates the settings of your service. You can change `port` and `tag` of the Docker image
+    as well as the `health_path` readiness probe (an empty string removes the probe).
     The service will be rebuilt after the application of the changes. If you used `volumes` you need to provide them in
     the request body again.
     ```json
     {
       "API-KEY": "a49bc0...",
       "port": "80:80,443:443",
-      "tag": "nightly"
+      "tag": "nightly",
+      "health_path": "/health"
     }
     ```
 

--- a/app.py
+++ b/app.py
@@ -31,7 +31,15 @@ else:
 with sqlite3.connect('services/services.db') as db:
     cursor = db.cursor()
     cursor.execute('CREATE TABLE IF NOT EXISTS repos(id TEXT PRIMARY KEY, url TEXT, mode TEXT,'
-                   'state TEXT, port TEXT, docker_root TEXT, image TEXT, tag TEXT)')
+                   'state TEXT, port TEXT, docker_root TEXT, image TEXT, tag TEXT,'
+                   "health_path TEXT DEFAULT '')")
+
+    # upgrade databases created before the health_path column existed
+    try:
+        cursor.execute("ALTER TABLE repos ADD COLUMN health_path TEXT DEFAULT ''")
+    except sqlite3.OperationalError:
+        pass
+
     cursor.close()
     db.commit()
 
@@ -55,6 +63,20 @@ def check_volumes(volumes):
         raise InvalidVolumeMappingException('Invalid volume mapping format provided')
 
     return volumes
+
+
+def check_health_path(health_path):
+    """
+    Validate an optional HTTP readiness probe path
+
+    :param health_path: URL path like '/health' or '' to disable the probe
+    :raises InvalidPathException
+    :return: the validated health path
+    """
+    if not isinstance(health_path, str) or (health_path and not health_path.startswith('/')):
+        raise InvalidPathException('Invalid health path provided')
+
+    return health_path
 
 
 def check_files(files):
@@ -122,11 +144,12 @@ def update_service(service_id: str):
 
         # search service
         service_cursor = service_db.cursor()
-        service_cursor.execute('SELECT * FROM repos WHERE id = ?', (service_id,))
+        service_cursor.execute('SELECT id, url, mode, state, port, docker_root, image, tag,'
+                               ' health_path FROM repos WHERE id = ?', (service_id,))
 
         # service exists
         if service_data := service_cursor.fetchone():
-            stored_id, url, mode, _, port, docker_root, image, tag = service_data
+            stored_id, url, mode, db_state, port, docker_root, image, tag, health_path = service_data
 
             # service update requested
             if (method := request.method) == 'POST':
@@ -159,11 +182,14 @@ def update_service(service_id: str):
             elif method == 'PATCH':
                 payload = request.json
 
-                # validate the volumes before any setting is changed
+                # validate the payload before any setting is changed
                 try:
                     volumes = check_volumes(payload['volumes'] if 'volumes' in payload else [])
-                except InvalidVolumeMappingException as e:
-                    logging.error(f'Invalid volume mapping provided: {e}')
+
+                    if 'health_path' in payload:
+                        check_health_path(payload['health_path'])
+                except (InvalidVolumeMappingException, InvalidPathException) as e:
+                    logging.error(f'Invalid patch payload provided: {e.message}')
                     return e.message, 400
 
                 if 'port' in payload:
@@ -181,6 +207,13 @@ def update_service(service_id: str):
                             update_cursor.execute(f'UPDATE repos SET {param} = ? WHERE id = ?',
                                                   (payload[param], service_id))
                             service_db.commit()
+
+                # unlike tag/port, an empty value clears the readiness probe
+                if 'health_path' in payload:
+                    update_cursor = service_db.cursor()
+                    update_cursor.execute('UPDATE repos SET health_path = ? WHERE id = ?',
+                                          (payload['health_path'], service_id))
+                    service_db.commit()
 
                 start_update(service_id, {}, volumes)
 
@@ -200,7 +233,12 @@ def update_service(service_id: str):
                     docker_client = docker.from_env()
                     container = docker_client.containers.get(service_id)
 
-                    docker_state = container.status.upper()
+                    # a failed update leaves the previous container serving,
+                    # so the stored state has to override the docker state
+                    if db_state == 'UPDATE FAILED':
+                        docker_state = db_state
+                    else:
+                        docker_state = container.status.upper()
 
                     return jsonify({
                         'id': service_id,
@@ -208,10 +246,12 @@ def update_service(service_id: str):
                         'errors': errors,
                         'image': image,
                         'tag': tag,
-                        'port': port
+                        'port': port,
+                        'health_path': health_path
                     }), 200
                 except NotFound:
-                    return jsonify({'id': service_id, 'state': 'BUILD FAILED', 'errors': errors}), 200
+                    state = db_state if db_state == 'UPDATE FAILED' else 'BUILD FAILED'
+                    return jsonify({'id': service_id, 'state': state, 'errors': errors}), 200
         # service does not exist
         else:
             logging.warning(f'Service {service_id} not found.')
@@ -253,6 +293,7 @@ def manage_services():
             url = data['url'] if 'url' in data else ''
             files = data['files'] if 'files' in data else {}
             volumes = data['volumes'] if 'volumes' in data else []
+            health_path = data['health_path'] if 'health_path' in data else ''
             mode = data['mode']
             port = ''
             image = ''
@@ -260,6 +301,7 @@ def manage_services():
 
             volumes = check_volumes(volumes)
             files = check_files(files)
+            health_path = check_health_path(health_path)
 
             # mode "docker" requires external port mapping
             if mode in ['docker', 'dockerfile'] and not valid(mode):
@@ -290,7 +332,8 @@ def manage_services():
 
             try:
                 # register new service
-                service_id = load_repository(url, mode, port, docker_root, image, tag, files)
+                service_id = load_repository(url, mode, port, docker_root, image, tag, files,
+                                             health_path)
 
                 # start new service
                 subprocess.Popen(['python', 'tasks/start_service.py', service_id, mode, docker_root, port, image, tag,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     restart: always
     build:
       context: .
+    # share the default bridge with the managed containers, so readiness
+    # probes can reach them directly (issue #149)
+    network_mode: bridge
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - $SSL_CERT_FILE:/ssl/server.crt

--- a/tasks/init_repo.py
+++ b/tasks/init_repo.py
@@ -6,7 +6,8 @@ from tasks.exceptions import RepositoryAlreadyExistsException, InvalidPathExcept
 import os
 
 
-def load_repository(url: str, mode: str, port: str, docker_root: str, dockerfile='.', tag='.', files=None):
+def load_repository(url: str, mode: str, port: str, docker_root: str, dockerfile='.', tag='.', files=None,
+                    health_path=''):
     """
     Clone a repository and store configuration into database
 
@@ -17,6 +18,7 @@ def load_repository(url: str, mode: str, port: str, docker_root: str, dockerfile
     :param docker_root: directory of repo with Dockerfile/docker-compose.yml
     :param dockerfile: docker image name from dockerhub
     :param tag: tag of dockerfile
+    :param health_path: optional HTTP readiness probe path
     :raises RepositoryAlreadyExistsException
     :raises InvalidPathException
     :return: id of the created repository
@@ -66,8 +68,8 @@ def load_repository(url: str, mode: str, port: str, docker_root: str, dockerfile
         cursor = db.cursor()
 
         # store configuration in SQLite db
-        cursor.execute('INSERT INTO repos VALUES (?, ?, ?, "INITIALIZING", ?, ?, ?, ?)',
-                       (link, url, mode, port, docker_root, dockerfile, tag))
+        cursor.execute('INSERT INTO repos VALUES (?, ?, ?, "INITIALIZING", ?, ?, ?, ?, ?)',
+                       (link, url, mode, port, docker_root, dockerfile, tag, health_path))
         db.commit()
         cursor.close()
 

--- a/tasks/rollout.py
+++ b/tasks/rollout.py
@@ -1,0 +1,224 @@
+"""
+Low-downtime update rollout for registered services (issue #149, phase 1).
+
+The updated image is prepared while the old container keeps serving; only
+then are the containers swapped. If the new container does not become ready,
+the previous image is restored, so a broken update never takes a service
+down for longer than the swap itself.
+"""
+import logging
+import os
+import subprocess
+import time
+
+import requests
+from docker.errors import APIError, BuildError, ImageNotFound, NotFound
+
+READINESS_TIMEOUT = 60
+
+
+def parse_ports(port: str):
+    """
+    Translate a port mapping string into the docker-py ports argument
+
+    :param port: mapping like '8080:80,8443:443'
+    :return: dict of (internal port, external port) pairs
+    """
+    ports = {}
+    for port_mapping in port.split(','):
+        ex_port, in_port = port_mapping.split(':')
+        ports[in_port] = ex_port
+    return ports
+
+
+def read_env_file():
+    """
+    Read the service's .env file from the current directory, if present
+
+    :return: list of environment variable lines or None
+    """
+    if os.path.exists('.env'):
+        with open('.env') as f:
+            return [line.strip('\n\r') for line in f.readlines()]
+    return None
+
+
+def run_container(docker_client, image_ref: str, service_id: str, ports: dict,
+                  env, volumes, tty=False):
+    """Start a detached service container with the standard settings"""
+    return docker_client.containers.run(image_ref, detach=True, tty=tty,
+                                        ports=ports, name=service_id,
+                                        restart_policy={'Name': 'always'},
+                                        environment=env, volumes=volumes)
+
+
+def prepare_image(docker_client, service_id: str, mode: str, image: str, tag: str):
+    """
+    Build or pull the updated image without touching the running container
+
+    :return: reference of the prepared image
+    :raises APIError, BuildError, ImageNotFound
+    """
+    if mode == 'docker':
+        logging.info('Building updated image...')
+        docker_client.images.build(path='.', tag=f'{service_id}:next', rm=True)
+        return f'{service_id}:next'
+
+    logging.info('Pulling updated image...')
+    docker_client.images.pull(image, tag)
+    return f'{image}:{tag}'
+
+
+def wait_until_ready(container, external_port: str, internal_port: str,
+                     health_path: str, timeout=READINESS_TIMEOUT):
+    """
+    Wait until the container is considered ready.
+
+    With a configured health_path the container has to answer HTTP 200 on it
+    (probed via its bridge IP and via the host-mapped port); without one the
+    running state counts as ready.
+
+    :return: True if the container became ready within the timeout
+    """
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        container.reload()
+
+        if container.status == 'exited':
+            return False
+
+        if health_path:
+            ip = container.attrs['NetworkSettings']['IPAddress']
+            urls = [f'http://{ip}:{internal_port}{health_path}'] if ip else []
+            urls.append(f'http://localhost:{external_port}{health_path}')
+
+            for url in urls:
+                try:
+                    if requests.get(url, timeout=2).status_code == 200:
+                        return True
+                except requests.RequestException:
+                    continue
+        elif container.status == 'running':
+            return True
+
+        time.sleep(1)
+
+    return False
+
+
+def set_state(db, cursor, service_id: str, state: str, error_message=''):
+    """Persist the service state and write error.txt in the current directory"""
+    cursor.execute('UPDATE repos SET state = ? WHERE id = ?', (state, service_id))
+    db.commit()
+
+    with open('error.txt', 'w') as f:
+        f.write(error_message)
+
+
+def rollback(docker_client, service_id: str, rollback_image, ports: dict,
+             env, volumes, tty):
+    """Restart the previous image after a failed update, if one exists"""
+    if not rollback_image:
+        return
+
+    logging.info(f'Rolling back {service_id} to the previous image...')
+    try:
+        run_container(docker_client, rollback_image, service_id, ports, env,
+                      volumes, tty)
+    except APIError as e:
+        logging.error(f'Rollback of {service_id} failed: {e}')
+
+
+def update_single_container_service(docker_client, service_id: str, mode: str,
+                                    db, cursor, port: str, image: str, tag: str,
+                                    health_path: str, volumes):
+    """
+    Update a 'docker' or 'dockerfile' service with minimal downtime.
+
+    The new image is prepared first (the old container keeps serving and is
+    untouched if that fails), then the containers are swapped. If the new
+    container does not become ready, the previous image is restored and the
+    state is set to UPDATE FAILED.
+
+    :return: True if the update succeeded
+    """
+    ports = parse_ports(port)
+    first_mapping = port.split(',')[0].split(':')
+    external_port, internal_port = first_mapping[0], first_mapping[1]
+    env = read_env_file()
+    tty = mode == 'dockerfile'
+
+    # prepare the new image; on failure the old container keeps serving
+    try:
+        image_ref = prepare_image(docker_client, service_id, mode, image, tag)
+    except (APIError, BuildError, ImageNotFound) as e:
+        message = (e.explanation if isinstance(e, APIError) else e.msg) or str(e)
+        logging.error(f'Preparing the updated image failed: {message}')
+        set_state(db, cursor, service_id, 'UPDATE FAILED', message)
+        return False
+
+    # swap containers, remembering the old image as rollback anchor
+    rollback_image = None
+    try:
+        old_container = docker_client.containers.get(service_id)
+        rollback_image = old_container.image.id
+        old_container.stop()
+        old_container.remove()
+    except NotFound:
+        logging.warning(f'No running container for {service_id} found')
+
+    if mode == 'docker':
+        # promote the staged build to the service's regular tag
+        docker_client.images.get(image_ref).tag(service_id, 'latest')
+        image_ref = f'{service_id}:latest'
+
+    try:
+        new_container = run_container(docker_client, image_ref, service_id,
+                                      ports, env, volumes, tty)
+    except APIError as e:
+        message = e.explanation or str(e)
+        logging.error(f'Starting the updated container failed: {message}')
+        rollback(docker_client, service_id, rollback_image, ports, env, volumes, tty)
+        set_state(db, cursor, service_id, 'UPDATE FAILED', message)
+        return False
+
+    if wait_until_ready(new_container, external_port, internal_port, health_path):
+        set_state(db, cursor, service_id, 'RUNNING')
+        return True
+
+    # readiness failed: restore the previous image
+    message = f'updated container did not become ready within {READINESS_TIMEOUT}s'
+    logging.error(message)
+    try:
+        new_container.stop()
+        new_container.remove()
+    except APIError as e:
+        logging.error(f'Removing the failed container failed: {e}')
+
+    rollback(docker_client, service_id, rollback_image, ports, env, volumes, tty)
+    set_state(db, cursor, service_id, 'UPDATE FAILED', message)
+    return False
+
+
+def update_compose_service(service_id: str, db, cursor):
+    """
+    Update a docker-compose service: build first (the old containers keep
+    serving), then let 'up -d' recreate only the changed containers instead
+    of tearing everything down beforehand.
+
+    :return: True if the update succeeded
+    """
+    try:
+        logging.info('Building updated docker-compose images...')
+        subprocess.run(['docker-compose', 'build'], check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        message = e.stderr.decode() if isinstance(e.stderr, bytes) else (e.stderr or str(e))
+        logging.error(f'Build process failed: {message}')
+        set_state(db, cursor, service_id, 'UPDATE FAILED', message)
+        return False
+
+    logging.info('Recreating changed containers...')
+    subprocess.run(['docker-compose', 'up', '-d'])
+    set_state(db, cursor, service_id, 'RUNNING')
+    return True

--- a/tasks/update_service.py
+++ b/tasks/update_service.py
@@ -4,7 +4,7 @@ import os
 from git.repo import Repo
 from json import loads
 import subprocess
-from start_service import start_service
+from rollout import update_single_container_service, update_compose_service
 import docker
 from docker.errors import NotFound
 import logging
@@ -52,7 +52,8 @@ if __name__ == '__main__':
         cursor = db.cursor()
 
         # check, if service exists
-        cursor.execute('SELECT docker_root, mode, port, image, tag FROM repos WHERE id = ?', (service_id,))
+        cursor.execute('SELECT docker_root, mode, port, image, tag, health_path FROM repos'
+                       ' WHERE id = ?', (service_id,))
 
         # service exists
         if service := cursor.fetchone():
@@ -81,10 +82,15 @@ if __name__ == '__main__':
 
             os.chdir(f'services/{service_id}/{service[0]}')
 
-            mode = service[1]
+            docker_root, mode, port, image, tag, health_path = service
 
-            # build new images and containers
-            stop_service(mode, service_id)
-            start_service(service_id, mode, db, cursor, service[2], service[3], service[4], volumes)
+            # prepare the new version while the old container keeps serving,
+            # then swap with readiness check and rollback (issue #149)
+            if mode in ['docker', 'dockerfile']:
+                update_single_container_service(docker.from_env(), service_id,
+                                                mode, db, cursor, port, image,
+                                                tag, health_path, volumes)
+            else:
+                update_compose_service(service_id, db, cursor)
 
             os.chdir(base_dir)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -129,7 +129,7 @@ def registered(tmp_path, monkeypatch):
     with sqlite3.connect(os.path.join("services", "services.db")) as db:
         db.execute(
             "INSERT INTO repos VALUES ('svc1', 'http://x/y.git', 'docker',"
-            " 'RUNNING', '8080:80', '.', 'img', 'tag')"
+            " 'RUNNING', '8080:80', '.', 'img', 'tag', '')"
         )
         db.commit()
 

--- a/tests/unit/test_app_extended.py
+++ b/tests/unit/test_app_extended.py
@@ -34,14 +34,15 @@ def app_env(tmp_path, monkeypatch):
 
 def register_service(service_id, url="", mode="dockerfile", state="RUNNING",
                      port="8080:80", docker_root=".", image="nginx",
-                     tag="alpine", errors=""):
+                     tag="alpine", errors="", health_path=""):
     """Insert a service row + workspace as the background tasks would."""
     os.makedirs(os.path.join("services", service_id), exist_ok=True)
     with open(os.path.join("services", service_id, "error.txt"), "w") as f:
         f.write(errors)
     with sqlite3.connect(os.path.join("services", "services.db")) as db:
-        db.execute("INSERT INTO repos VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                   (service_id, url, mode, state, port, docker_root, image, tag))
+        db.execute("INSERT INTO repos VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                   (service_id, url, mode, state, port, docker_root, image, tag,
+                    health_path))
         db.commit()
 
 
@@ -77,7 +78,7 @@ def test_register_dockerfile_service(app_env):
     assert resp.get_json() == {"id": "nginx", "state": "CREATED"}
     assert os.path.isdir(os.path.join("services", "nginx"))
     assert service_row("nginx") == ("nginx", "", "dockerfile", "INITIALIZING",
-                                    "8080:80", ".", "nginx", "alpine")
+                                    "8080:80", ".", "nginx", "alpine", "")
     popen.assert_called_once_with(
         ["python", "tasks/start_service.py", "nginx", "dockerfile", ".",
          "8080:80", "nginx", "alpine", "[]"])
@@ -233,7 +234,7 @@ def test_register_docker_mode_uses_cloned_repository(app_env):
     assert resp.status_code == 200
     assert resp.get_json() == {"id": "example-org-repo", "state": "CREATED"}
     load.assert_called_once_with("https://example.org/org/repo.git", "docker",
-                                 "8080:80", ".", "", "", {})
+                                 "8080:80", ".", "", "", {}, "")
 
 
 def test_register_reports_failed_clone(app_env):
@@ -265,6 +266,7 @@ def test_get_state_of_running_container(app_env):
         "image": "nginx",
         "tag": "alpine",
         "port": "8080:80",
+        "health_path": "",
     }
     from_env.return_value.containers.get.assert_called_once_with("svc")
 
@@ -323,6 +325,93 @@ def test_unknown_service_id_is_escaped_in_404(app_env):
     assert resp.status_code == 404
     assert b"<img" not in resp.data
     assert b"&lt;img" in resp.data
+
+
+def test_register_stores_health_path(app_env):
+    # issue #149: optional HTTP readiness probe path
+    app_module, client = app_env
+    with mock.patch.object(app_module.subprocess, "Popen"):
+        resp = post_service(client, mode="dockerfile", image="nginx",
+                            tag="alpine", port="8080:80",
+                            health_path="/health")
+
+    assert resp.status_code == 200
+    assert service_row("nginx")[8] == "/health"
+
+
+@pytest.mark.parametrize("health_path", ["health", 5, ["/health"]])
+def test_register_rejects_invalid_health_path(app_env, health_path):
+    app_module, client = app_env
+    with mock.patch.object(app_module.subprocess, "Popen") as popen:
+        resp = post_service(client, mode="dockerfile", image="nginx",
+                            tag="alpine", port="8080:80",
+                            health_path=health_path)
+
+    assert resp.status_code == 400
+    assert b"Invalid health path provided" in resp.data
+    popen.assert_not_called()
+
+
+def test_patch_updates_and_clears_health_path(app_env):
+    app_module, client = app_env
+    register_service("svc")
+
+    with mock.patch.object(app_module.subprocess, "Popen"):
+        resp = client.patch("/service/svc",
+                            json={"API-KEY": API_KEY,
+                                  "health_path": "/health"})
+        assert resp.status_code == 200
+        assert service_row("svc")[8] == "/health"
+
+        # unlike tag/port, an empty value clears the probe
+        resp = client.patch("/service/svc",
+                            json={"API-KEY": API_KEY, "health_path": ""})
+        assert resp.status_code == 200
+        assert service_row("svc")[8] == ""
+
+
+def test_patch_rejects_invalid_health_path(app_env):
+    app_module, client = app_env
+    register_service("svc", health_path="/health")
+
+    with mock.patch.object(app_module.subprocess, "Popen") as popen:
+        resp = client.patch("/service/svc",
+                            json={"API-KEY": API_KEY, "health_path": "health"})
+
+    assert resp.status_code == 400
+    assert service_row("svc")[8] == "/health"
+    popen.assert_not_called()
+
+
+def test_get_reports_update_failed_over_running_container(app_env):
+    # issue #149: after a rollback the old container keeps running, but the
+    # API has to surface the failed update
+    app_module, client = app_env
+    register_service("svc", state="UPDATE FAILED",
+                     errors="updated container did not become ready")
+
+    with mock.patch.object(app_module.docker, "from_env") as from_env:
+        from_env.return_value.containers.get.return_value.status = "running"
+        resp = client.get("/service/svc")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["state"] == "UPDATE FAILED"
+    assert "did not become ready" in data["errors"]
+
+
+def test_get_reports_update_failed_without_container(app_env):
+    from docker.errors import NotFound
+
+    app_module, client = app_env
+    register_service("svc", state="UPDATE FAILED", errors="update broke")
+
+    with mock.patch.object(app_module.docker, "from_env") as from_env:
+        from_env.return_value.containers.get.side_effect = NotFound("gone")
+        resp = client.get("/service/svc")
+
+    assert resp.status_code == 200
+    assert resp.get_json()["state"] == "UPDATE FAILED"
 
 
 def test_get_state_while_initializing_reports_no_errors(app_env):

--- a/tests/unit/test_init_repo.py
+++ b/tests/unit/test_init_repo.py
@@ -22,7 +22,7 @@ def workspace(tmp_path, monkeypatch):
     with sqlite3.connect(os.path.join("services", "services.db")) as db:
         db.execute(
             "CREATE TABLE repos(id TEXT PRIMARY KEY, url TEXT, mode TEXT, state TEXT,"
-            " port TEXT, docker_root TEXT, image TEXT, tag TEXT)"
+            " port TEXT, docker_root TEXT, image TEXT, tag TEXT, health_path TEXT DEFAULT '')"
         )
         db.commit()
     return tmp_path

--- a/tests/unit/test_rollout.py
+++ b/tests/unit/test_rollout.py
@@ -1,0 +1,291 @@
+"""Unit tests for tasks/rollout.py — the low-downtime update flow (issue #149).
+
+All docker interactions are stubbed; every test runs in a temp directory
+because the rollout writes error.txt into the service's docker_root.
+"""
+import itertools
+import os
+import sqlite3
+import subprocess
+import sys
+from unittest import mock
+
+import pytest
+import requests
+from docker.errors import APIError, BuildError, ImageNotFound, NotFound
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))), "tasks"))
+
+import rollout  # noqa: E402
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def db_env(workspace):
+    """Real in-memory-style DB so state transitions can be asserted."""
+    db = sqlite3.connect("services.db")
+    db.execute("CREATE TABLE repos(id TEXT PRIMARY KEY, url TEXT, mode TEXT,"
+               " state TEXT, port TEXT, docker_root TEXT, image TEXT, tag TEXT,"
+               " health_path TEXT DEFAULT '')")
+    db.execute("INSERT INTO repos VALUES ('svc', '', 'docker', 'UPDATING',"
+               " '8080:80', '.', '', '', '')")
+    db.commit()
+    yield db, db.cursor()
+    db.close()
+
+
+def service_state(db):
+    return db.execute("SELECT state FROM repos WHERE id = 'svc'").fetchone()[0]
+
+
+def read_error_file():
+    with open("error.txt") as f:
+        return f.read()
+
+
+@pytest.fixture
+def docker_client():
+    client = mock.Mock()
+    client.images.build.return_value = (mock.Mock(), iter([]))
+    client.containers.get.return_value.image.id = "sha256:old-image"
+    return client
+
+
+@pytest.fixture
+def instant_clock():
+    """Make wait_until_ready iterate without real sleeping."""
+    with mock.patch.object(rollout.time, "sleep"), \
+            mock.patch.object(rollout.time, "monotonic",
+                              side_effect=itertools.count(0.0, 1.0)):
+        yield
+
+
+def test_parse_ports():
+    assert rollout.parse_ports("8080:80") == {"80": "8080"}
+    assert rollout.parse_ports("8080:80,8443:443") == {"80": "8080",
+                                                       "443": "8443"}
+
+
+class TestWaitUntilReady:
+    def test_running_without_health_path_is_ready(self, instant_clock):
+        container = mock.Mock(status="running")
+
+        assert rollout.wait_until_ready(container, "8080", "80", "") is True
+
+    def test_exited_container_is_not_ready(self, instant_clock):
+        container = mock.Mock(status="exited")
+
+        assert rollout.wait_until_ready(container, "8080", "80", "") is False
+
+    def test_health_path_polls_until_200(self, instant_clock):
+        container = mock.Mock(status="running")
+        container.attrs = {"NetworkSettings": {"IPAddress": "172.17.0.5"}}
+        responses = [mock.Mock(status_code=503), mock.Mock(status_code=200)]
+
+        with mock.patch.object(rollout.requests, "get",
+                               side_effect=responses) as get:
+            assert rollout.wait_until_ready(container, "8080", "80",
+                                            "/health") is True
+
+        assert get.call_args_list[0].args[0] == "http://172.17.0.5:80/health"
+
+    def test_health_path_falls_back_to_mapped_port(self, instant_clock):
+        container = mock.Mock(status="running")
+        container.attrs = {"NetworkSettings": {"IPAddress": "172.17.0.5"}}
+        responses = [requests.ConnectionError(), mock.Mock(status_code=200)]
+
+        with mock.patch.object(rollout.requests, "get",
+                               side_effect=responses) as get:
+            assert rollout.wait_until_ready(container, "8080", "80",
+                                            "/health") is True
+
+        assert get.call_args_list[1].args[0] == "http://localhost:8080/health"
+
+    def test_health_path_times_out(self, instant_clock):
+        container = mock.Mock(status="running")
+        container.attrs = {"NetworkSettings": {"IPAddress": "172.17.0.5"}}
+
+        with mock.patch.object(rollout.requests, "get",
+                               side_effect=requests.ConnectionError()):
+            assert rollout.wait_until_ready(container, "8080", "80", "/health",
+                                            timeout=3) is False
+
+
+class TestUpdateSingleContainerService:
+    def run_update(self, docker_client, db_env, mode="docker", image="",
+                   tag="", health_path="", volumes=None):
+        db, cursor = db_env
+        return rollout.update_single_container_service(
+            docker_client, "svc", mode, db, cursor, "8080:80", image, tag,
+            health_path, volumes or [])
+
+    def test_successful_docker_update(self, docker_client, db_env,
+                                      instant_clock):
+        db, _ = db_env
+        docker_client.containers.run.return_value.status = "running"
+        old_container = docker_client.containers.get.return_value
+
+        assert self.run_update(docker_client, db_env) is True
+
+        # the new image is staged, promoted and started
+        docker_client.images.build.assert_called_once_with(path=".",
+                                                           tag="svc:next",
+                                                           rm=True)
+        docker_client.images.get.assert_called_once_with("svc:next")
+        docker_client.images.get.return_value.tag.assert_called_once_with(
+            "svc", "latest")
+        assert docker_client.containers.run.call_args.args[0] == "svc:latest"
+        old_container.stop.assert_called_once()
+        old_container.remove.assert_called_once()
+        assert service_state(db) == "RUNNING"
+        assert read_error_file() == ""
+
+    def test_build_happens_before_old_container_is_stopped(self, docker_client,
+                                                           db_env,
+                                                           instant_clock):
+        # the phase-1 property: a build failure must leave the old
+        # container untouched
+        docker_client.containers.run.return_value.status = "running"
+        calls = []
+        docker_client.images.build.side_effect = \
+            lambda **kw: calls.append("build") or (mock.Mock(), iter([]))
+        docker_client.containers.get.return_value.stop.side_effect = \
+            lambda **kw: calls.append("stop")
+
+        self.run_update(docker_client, db_env)
+
+        assert calls.index("build") < calls.index("stop")
+
+    def test_failed_build_keeps_old_container_serving(self, docker_client,
+                                                      db_env):
+        db, _ = db_env
+        docker_client.images.build.side_effect = BuildError("broken Dockerfile",
+                                                            build_log=[])
+
+        assert self.run_update(docker_client, db_env) is False
+
+        docker_client.containers.get.return_value.stop.assert_not_called()
+        docker_client.containers.run.assert_not_called()
+        assert service_state(db) == "UPDATE FAILED"
+        assert read_error_file() == "broken Dockerfile"
+
+    def test_failed_pull_keeps_old_container_serving(self, docker_client,
+                                                     db_env):
+        db, _ = db_env
+        docker_client.images.pull.side_effect = ImageNotFound("no such image")
+
+        assert self.run_update(docker_client, db_env, mode="dockerfile",
+                               image="nginx", tag="broken") is False
+
+        docker_client.containers.get.return_value.stop.assert_not_called()
+        assert service_state(db) == "UPDATE FAILED"
+        assert "no such image" in read_error_file()
+
+    def test_unready_container_rolls_back_to_old_image(self, docker_client,
+                                                       db_env, instant_clock):
+        db, _ = db_env
+        new_container = mock.Mock(status="running")
+        new_container.attrs = {"NetworkSettings": {"IPAddress": ""}}
+        docker_client.containers.run.side_effect = [new_container,
+                                                    mock.Mock()]
+
+        with mock.patch.object(rollout.requests, "get",
+                               side_effect=requests.ConnectionError()), \
+                mock.patch.object(rollout, "READINESS_TIMEOUT", 3):
+            result = self.run_update(docker_client, db_env,
+                                     health_path="/health")
+
+        assert result is False
+        # the failed container is removed, the old image restarted
+        new_container.stop.assert_called_once()
+        new_container.remove.assert_called_once()
+        assert docker_client.containers.run.call_count == 2
+        rollback_call = docker_client.containers.run.call_args_list[1]
+        assert rollback_call.args[0] == "sha256:old-image"
+        assert service_state(db) == "UPDATE FAILED"
+        assert "did not become ready" in read_error_file()
+
+    def test_failed_start_rolls_back_to_old_image(self, docker_client, db_env):
+        db, _ = db_env
+        docker_client.containers.run.side_effect = [
+            APIError("conflict", explanation="port already allocated"),
+            mock.Mock(),
+        ]
+
+        assert self.run_update(docker_client, db_env) is False
+
+        rollback_call = docker_client.containers.run.call_args_list[1]
+        assert rollback_call.args[0] == "sha256:old-image"
+        assert service_state(db) == "UPDATE FAILED"
+        assert read_error_file() == "port already allocated"
+
+    def test_first_start_without_old_container(self, docker_client, db_env,
+                                               instant_clock):
+        db, _ = db_env
+        docker_client.containers.get.side_effect = NotFound("no container")
+        docker_client.containers.run.return_value.status = "running"
+
+        assert self.run_update(docker_client, db_env) is True
+        assert service_state(db) == "RUNNING"
+
+    def test_unready_without_old_container_reports_failure(self, docker_client,
+                                                           db_env,
+                                                           instant_clock):
+        db, _ = db_env
+        docker_client.containers.get.side_effect = NotFound("no container")
+        new_container = mock.Mock(status="exited")
+        docker_client.containers.run.return_value = new_container
+
+        assert self.run_update(docker_client, db_env) is False
+
+        # no rollback anchor: only the failed container is cleaned up
+        assert docker_client.containers.run.call_count == 1
+        assert service_state(db) == "UPDATE FAILED"
+
+    def test_dockerfile_mode_runs_pulled_image(self, docker_client, db_env,
+                                               instant_clock):
+        db, _ = db_env
+        docker_client.containers.run.return_value.status = "running"
+
+        assert self.run_update(docker_client, db_env, mode="dockerfile",
+                               image="nginx", tag="alpine") is True
+
+        docker_client.images.pull.assert_called_once_with("nginx", "alpine")
+        run_call = docker_client.containers.run.call_args
+        assert run_call.args[0] == "nginx:alpine"
+        assert run_call.kwargs["tty"] is True
+        assert service_state(db) == "RUNNING"
+
+
+class TestUpdateComposeService:
+    def test_build_runs_before_recreation(self, db_env):
+        db, cursor = db_env
+
+        with mock.patch.object(rollout.subprocess, "run") as run:
+            assert rollout.update_compose_service("svc", db, cursor) is True
+
+        assert run.call_args_list[0].args[0] == ["docker-compose", "build"]
+        assert run.call_args_list[1].args[0] == ["docker-compose", "up", "-d"]
+        # no 'docker-compose down' anywhere: containers are recreated in place
+        commands = [call.args[0] for call in run.call_args_list]
+        assert ["docker-compose", "down"] not in commands
+        assert service_state(db) == "RUNNING"
+
+    def test_failed_build_keeps_old_containers(self, db_env):
+        db, cursor = db_env
+        error = subprocess.CalledProcessError(1, ["docker-compose", "build"],
+                                              stderr=b"compose build failed")
+
+        with mock.patch.object(rollout.subprocess, "run",
+                               side_effect=error) as run:
+            assert rollout.update_compose_service("svc", db, cursor) is False
+
+        assert run.call_count == 1  # 'up -d' is never reached
+        assert service_state(db) == "UPDATE FAILED"
+        assert "compose build failed" in read_error_file()


### PR DESCRIPTION
Implements **phase 1** of #149 (the reverse-proxy blue-green switch remains as phase 2).

**Before:** an update destroyed the running container, then built the new image — downtime = the whole build, and a failed build left the service dead.

**Now (`tasks/rollout.py`):**
1. the new image is built (`<id>:next`) or pulled **while the old container keeps serving** — a failed build/pull never touches the running service (state `UPDATE FAILED`, reason in `error.txt`)
2. only then are the containers swapped (downtime = the swap, a few seconds)
3. the new container has to become **ready**: `HTTP 200` on the service's optional `health_path` (probed via bridge IP and mapped port, 60 s timeout), or simply `running` if no probe is configured
4. if it doesn't, the new container is removed and the **previous image is restored** (rollback anchor = old container's image id); the API reports `UPDATE FAILED` with the reason while the old version serves again

`docker-compose` services get the interim improvement: `build` first, then `up -d` recreation in place — no `docker-compose down` anymore.

**API additions** (backwards compatible):
- optional `health_path` on registration and PATCH (empty string clears it), persisted in a new DB column with automatic migration, returned by GET
- new state `UPDATE FAILED`, surfaced by `GET /service/<id>` even while the rolled-back container is running

The updater's compose service joins the default bridge (`network_mode: bridge`) so readiness probes can reach managed containers. README documents the new flow.

**Testing:** 26 new unit tests — swap ordering (build strictly before stop), build/pull failure leaving the old container untouched, readiness polling (bridge + fallback URL, timeout), rollback on unready/unstartable containers, no-old-container edge cases, compose ordering without `down`, and the `health_path` API surface. 123 tests total, coverage 85%.

Part of #149